### PR TITLE
Feat/map preloading

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,11 +91,11 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'com.expofp:common:4.10.0'
-  implementation 'com.expofp:fplan:4.10.0'
+  implementation 'com.expofp:common:4.11.0'
+  implementation 'com.expofp:fplan:4.11.0'
 
-  implementation 'com.expofp:crowdconnected:4.10.0'
-  // implementation 'com.expofp:crowdconnectedbackground:4.10.0'
+  implementation 'com.expofp:crowdconnected:4.11.0'
+  // implementation 'com.expofp:crowdconnectedbackground:4.11.0'
   implementation 'net.crowdconnected.android.core:android-core:2.0.2'
   implementation 'net.crowdconnected.android.ips:android-ips:2.0.2'
   implementation 'net.crowdconnected.android.geo:android-geo:2.0.2'

--- a/android/src/main/java/com/expofp/ExpofpViewManager.kt
+++ b/android/src/main/java/com/expofp/ExpofpViewManager.kt
@@ -1,20 +1,11 @@
 package com.expofp
 
-import android.Manifest
-import android.app.Activity
-import android.app.AlertDialog
 import android.app.Application
-import android.os.Build
 import android.util.Log
 import android.view.View
-import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityCompat
 import com.expofp.common.GlobalLocationProvider
 import com.expofp.crowdconnected.CrowdConnectedProvider
 import com.expofp.crowdconnected.Mode
-import com.expofp.crowdconnected.Settings
-// import com.expofp.crowdconnectedbackground.CrowdConnectedBackgroundProvider
 import com.expofp.fplan.FplanView
 import com.expofp.fplan.models.FplanViewState
 import com.facebook.react.bridge.ReadableMap
@@ -22,6 +13,9 @@ import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.expofp.R
+import com.expofp.fplan.contracts.DownloadOfflinePlanCallback
+import com.expofp.fplan.models.OfflinePlanInfo
+import android.content.res.AssetManager
 
 class ExpofpViewManager : SimpleViewManager<View>() {
     private var reactContext: ThemedReactContext? = null
@@ -68,7 +62,54 @@ class ExpofpViewManager : SimpleViewManager<View>() {
                 GlobalLocationProvider.start()
             }
             if (view.state.equals(FplanViewState.Created)) {
-                view.load(it.getString("url") ?: "", com.expofp.fplan.models.Settings().withGlobalLocationProvider());
+                val info = ExpofpModule.downloadedOfflinePlanInfo
+                val url = it.getString("url") ?: ""
+                val expoKey = url.substringAfter("https://").substringBefore(".expofp.com")
+
+                val offlinePlanManager = FplanView.getOfflinePlanManager(reactContext)
+                val latestOfflinePlan = offlinePlanManager.allOfflinePlansFromCache
+                    .filter { offlinePlanInfo -> offlinePlanInfo.expoKey == expoKey }
+                    .maxByOrNull { offlinePlanInfo -> offlinePlanInfo.version }
+                if (latestOfflinePlan != null) {
+                    Log.d("ExpofpModule", latestOfflinePlan.expoKey)
+                    view.openOfflinePlan(latestOfflinePlan, "", com.expofp.fplan.models.Settings().withGlobalLocationProvider())
+                } else {
+                    val ctx = this.reactContext
+                    if (ctx != null) {
+                        val am = ctx.assets
+                        val cachePlanExists = try {
+                            am.open("${expoKey}.zip").close()
+                            true
+                        } catch (e: Exception) {
+                            false
+                        }
+
+                        if (cachePlanExists) {
+                            try {
+                                Log.d("ExpofpModule", "openZipFromAssets: ${'$'}candidate")
+                                view.openZipFromAssets("${expoKey}.zip", "", com.expofp.fplan.models.Settings().withGlobalLocationProvider(), ctx)
+                            } catch (e: Exception) {
+                                Log.d("ExpofpModule", "failed to open asset zip, loading url: ${'$'}url")
+                                view.load(url, com.expofp.fplan.models.Settings().withGlobalLocationProvider())
+                            }
+                        } else {
+                            Log.d("ExpofpModule", "asset zip not found, loading url: ${'$'}url")
+                            view.load(url, com.expofp.fplan.models.Settings().withGlobalLocationProvider())
+                        }
+                    } else {
+                        view.load(url, com.expofp.fplan.models.Settings().withGlobalLocationProvider())
+                    }
+                }
+
+                offlinePlanManager.downloadOfflinePlanToCache(expoKey, object : DownloadOfflinePlanCallback {
+                    override fun onCompleted(offlinePlanInfo: OfflinePlanInfo) {
+                        Log.d("ExpofpModule", "downloaded offline plan: ${'$'}{offlinePlanInfo.expoKey} v${'$'}{offlinePlanInfo.version}")
+                    }
+
+                    override fun onError(message: String) {
+                        Log.e("ExpofpModule", "offline plan download failed: ${'$'}message")
+                    }
+                })
             }
         }
     }

--- a/ios/ExpofpViewManager.swift
+++ b/ios/ExpofpViewManager.swift
@@ -88,7 +88,7 @@ struct ExpoFP: View {
 
         if let cachePath = SharedFplanView.getFilePathFromCache() {
             let pathComponents = cachePath.absoluteString.components(separatedBy: "/")
-            let cachedExpoKey = pathComponents[pathComponents.count - 2]
+            let cachedExpoKey = pathComponents.count >= 2 ? pathComponents[pathComponents.count - 2] : ""
             print("cachePath: \(cachePath.absoluteString)")
             print("cachedExpoKey: \(cachedExpoKey)")
             if cachedExpoKey == key {
@@ -114,7 +114,7 @@ struct ExpoFP: View {
         print("downloading the map")
         fplanView.downloadZipToCache(urlString) { htmlFilePath, error in
             if let error = error {
-                print("error downloading the map: \(error.localizedDescription)")
+                print("error downloading the map: \(error)")
             } else {
                 print("success downloading the map")
                 if let htmlFilePath = htmlFilePath {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Offline-first loading: prefer cached maps, then bundled ZIPs, then network.

- Enhancements
  - Automatic background download/refresh of offline maps after initial load.
  - Faster startup and improved reliability in low-connectivity scenarios.
  - Consistent offline behavior across Android and iOS.

- Chores
  - Updated Android dependencies for com.expofp packages to 4.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->